### PR TITLE
Fix plane visibility and control

### DIFF
--- a/gamee/lib/src/view/game_page.dart
+++ b/gamee/lib/src/view/game_page.dart
@@ -15,18 +15,26 @@ class GamePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(mode == GameMode.arcade ? 'Аркада' : 'Бесконечный')),
       body: GestureDetector(
-        onTap: () {
+        onPanStart: (d) {
           if (!cubit.state.isRunning) {
             cubit.startGame(mode);
           }
+          final box = context.findRenderObject() as RenderBox?;
+          if (box != null) {
+            final local = box.globalToLocal(d.globalPosition);
+            cubit.movePlayer(local.dx / box.size.width);
+          }
+          cubit.startShooting();
         },
-        onHorizontalDragUpdate: (d) {
+        onPanUpdate: (d) {
           final box = context.findRenderObject() as RenderBox?;
           if (box != null) {
             final local = box.globalToLocal(d.globalPosition);
             cubit.movePlayer(local.dx / box.size.width);
           }
         },
+        onPanEnd: (_) => cubit.stopShooting(),
+        onPanCancel: cubit.stopShooting,
         child: BlocBuilder<GameCubit, GameState>(
           builder: (context, state) {
             return Stack(
@@ -64,7 +72,7 @@ class GamePage extends StatelessWidget {
                     child: Container(width: 4, height: 10, color: Colors.yellow),
                   ),
                 Positioned(
-                  bottom: 20,
+                  bottom: state.isRunning ? 20 : 70,
                   left: state.playerX * MediaQuery.of(context).size.width - 15,
                   child: Image.asset(
                     'assets/images/player.png',
@@ -99,26 +107,27 @@ class GamePage extends StatelessWidget {
                       ],
                     ),
                   ),
-                Positioned(
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                  child: Container(
-                    color: Colors.grey.shade900,
-                    height: 50,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        TextButton(
-                          onPressed: () => Navigator.of(context).push(
-                            MaterialPageRoute(builder: (_) => const StorePage()),
+                if (!state.isRunning)
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: Container(
+                      color: Colors.grey.shade900,
+                      height: 50,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).push(
+                              MaterialPageRoute(builder: (_) => const StorePage()),
+                            ),
+                            child: const Text('Магазин'),
                           ),
-                          child: const Text('Магазин'),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
-                ),
               ],
             );
           },

--- a/gamee/lib/src/view_model/game_cubit.dart
+++ b/gamee/lib/src/view_model/game_cubit.dart
@@ -14,6 +14,7 @@ class GameCubit extends Cubit<GameState> {
 
   Timer? _ticker;
   Timer? _shootTicker;
+  bool _shooting = false;
   final Random _random = Random();
   int _idCounter = 0;
 
@@ -31,14 +32,29 @@ class GameCubit extends Cubit<GameState> {
   void startGame(GameMode mode) {
     _ticker?.cancel();
     _shootTicker?.cancel();
+    _shooting = false;
     emit(GameState(mode: mode, isRunning: true, playerX: 0.5));
     _ticker = Timer.periodic(const Duration(milliseconds: 16), _onTick);
-    _shootTicker = Timer.periodic(const Duration(milliseconds: 300), (_) => _spawnBullet());
+  }
+
+  void startShooting() {
+    if (_shooting) return;
+    _shooting = true;
+    _spawnBullet();
+    _shootTicker =
+        Timer.periodic(const Duration(milliseconds: 300), (_) => _spawnBullet());
+  }
+
+  void stopShooting() {
+    if (!_shooting) return;
+    _shooting = false;
+    _shootTicker?.cancel();
+    _shootTicker = null;
   }
 
   void _spawnBullet() {
     if (!state.isRunning) return;
-    final newBullet = Bullet(id: _idCounter++, x: state.playerX, y: 0.85);
+    final newBullet = Bullet(id: _idCounter++, x: state.playerX, y: 0.9);
     emit(state.copyWith(bullets: [...state.bullets, newBullet]));
   }
 
@@ -99,7 +115,7 @@ class GameCubit extends Cubit<GameState> {
 
     // check player collision
     for (final ob in updatedObstacles) {
-      if (ob.y > 0.9 && (ob.x - state.playerX).abs() < 0.05) {
+      if (ob.y > 0.95 && (ob.x - state.playerX).abs() < 0.05) {
         emit(state.copyWith(isRunning: false, isGameOver: true));
         _ticker?.cancel();
         _shootTicker?.cancel();


### PR DESCRIPTION
## Summary
- make bullets fire only while touching the screen
- show player plane above the bottom UI and hide store while playing
- adjust collision detection near the bottom of the screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663e224a1c832a9a764f7bbc7a0edc