### PR TITLE
Implement store with skins and upgrades

### DIFF
--- a/gamee/lib/src/model/skin_item.dart
+++ b/gamee/lib/src/model/skin_item.dart
@@ -1,0 +1,13 @@
+class SkinItem {
+  final int id;
+  final String title;
+  final String image;
+  final int price;
+
+  const SkinItem({
+    required this.id,
+    required this.title,
+    required this.image,
+    required this.price,
+  });
+}

--- a/gamee/lib/src/model/upgrade_item.dart
+++ b/gamee/lib/src/model/upgrade_item.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class UpgradeItem {
+  final int id;
+  final String title;
+  final String description;
+  final IconData icon;
+  final int price;
+
+  const UpgradeItem({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.price,
+  });
+}

--- a/gamee/lib/src/view/game_page.dart
+++ b/gamee/lib/src/view/game_page.dart
@@ -84,7 +84,7 @@ class GamePage extends StatelessWidget {
                 Positioned(
                   top: 10,
                   left: 10,
-                  child: Text('Coins: ${state.coins}'),
+                  child: Text('Coins: ${state.coinBalance}'),
                 ),
                 if (!state.isRunning && !state.isGameOver)
                   Center(

--- a/gamee/lib/src/view/store_page.dart
+++ b/gamee/lib/src/view/store_page.dart
@@ -1,16 +1,126 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../model/skin_item.dart';
+import '../model/upgrade_item.dart';
 import '../view_model/game_cubit.dart';
+import '../view_model/game_state.dart';
+
+const List<SkinItem> _skins = [
+  SkinItem(id: 1, title: 'Default', image: 'assets/images/player.png', price: 100),
+  SkinItem(id: 2, title: 'Enemy', image: 'assets/images/enemy.png', price: 200),
+];
+
+const List<UpgradeItem> _upgrades = [
+  UpgradeItem(
+    id: 1,
+    title: 'Attack Speed',
+    description: 'Shoot faster',
+    icon: Icons.flash_on,
+    price: 150,
+  ),
+  UpgradeItem(
+    id: 2,
+    title: 'Damage',
+    description: 'Increase bullet damage',
+    icon: Icons.whatshot,
+    price: 200,
+  ),
+];
 
 class StorePage extends StatelessWidget {
   const StorePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final coins = context.select((GameCubit c) => c.state.coins);
-    return Scaffold(
-      appBar: AppBar(title: const Text('Магазин')),
-      body: Center(child: Text('Монет: $coins\nЗдесь будут улучшения')),
+    return BlocBuilder<GameCubit, GameState>(
+      builder: (context, state) {
+        return DefaultTabController(
+          length: 2,
+          child: Scaffold(
+            appBar: AppBar(
+              title: const Text('Store'),
+              actions: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Center(child: Text('Coins: ${state.coinBalance}')),
+                ),
+              ],
+              bottom: const TabBar(
+                tabs: [
+                  Tab(text: 'Skins'),
+                  Tab(text: 'Upgrades'),
+                ],
+              ),
+            ),
+            body: TabBarView(
+              children: [
+                _buildSkins(context, state),
+                _buildUpgrades(context, state),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSkins(BuildContext context, GameState state) {
+    return ListView.builder(
+      scrollDirection: Axis.horizontal,
+      itemCount: _skins.length,
+      itemBuilder: (context, index) {
+        final item = _skins[index];
+        final disabled =
+            state.coinBalance < item.price || state.purchasedSkinIds.contains(item.id);
+        return Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Image.asset(item.image, width: 64, height: 64),
+              const SizedBox(height: 4),
+              Text(item.title),
+              Text('Price: ${item.price}'),
+              const SizedBox(height: 4),
+              ElevatedButton(
+                onPressed: disabled
+                    ? null
+                    : () => context.read<GameCubit>().purchaseSkin(item.id),
+                child: const Text('Buy'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildUpgrades(BuildContext context, GameState state) {
+    return ListView.builder(
+      itemCount: _upgrades.length,
+      itemBuilder: (context, index) {
+        final up = _upgrades[index];
+        final disabled = state.coinBalance < up.price ||
+            state.purchasedUpgradeIds.contains(up.id);
+        return ListTile(
+          leading: Icon(up.icon),
+          title: Text(up.title),
+          subtitle: Text(up.description),
+          trailing: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('${up.price}'),
+              const SizedBox(height: 4),
+              ElevatedButton(
+                onPressed:
+                    disabled ? null : () => context.read<GameCubit>().purchaseUpgrade(up.id),
+                child: const Text('Buy'),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/gamee/lib/src/view_model/game_cubit.dart
+++ b/gamee/lib/src/view_model/game_cubit.dart
@@ -18,15 +18,25 @@ class GameCubit extends Cubit<GameState> {
   final Random _random = Random();
   int _idCounter = 0;
 
+  static const Map<int, int> _skinPrices = {
+    1: 100,
+    2: 200,
+  };
+
+  static const Map<int, int> _upgradePrices = {
+    1: 150,
+    2: 200,
+  };
+
   Future<void> loadState() async {
     final prefs = await SharedPreferences.getInstance();
     final coins = prefs.getInt('coins') ?? 0;
-    emit(state.copyWith(coins: coins));
+    emit(state.copyWith(coinBalance: coins));
   }
 
   Future<void> _saveCoins() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt('coins', state.coins);
+    await prefs.setInt('coins', state.coinBalance);
   }
 
   void startGame(GameMode mode) {
@@ -147,7 +157,33 @@ class GameCubit extends Cubit<GameState> {
   }
 
   void addCoins(int count) {
-    emit(state.copyWith(coins: state.coins + count));
+    emit(state.copyWith(coinBalance: state.coinBalance + count));
+    _saveCoins();
+  }
+
+  void purchaseSkin(int id) {
+    final price = _skinPrices[id] ?? 0;
+    if (state.coinBalance < price || state.purchasedSkinIds.contains(id)) return;
+    emit(
+      state.copyWith(
+        coinBalance: state.coinBalance - price,
+        purchasedSkinIds: {...state.purchasedSkinIds, id},
+      ),
+    );
+    _saveCoins();
+  }
+
+  void purchaseUpgrade(int id) {
+    final price = _upgradePrices[id] ?? 0;
+    if (state.coinBalance < price || state.purchasedUpgradeIds.contains(id)) {
+      return;
+    }
+    emit(
+      state.copyWith(
+        coinBalance: state.coinBalance - price,
+        purchasedUpgradeIds: {...state.purchasedUpgradeIds, id},
+      ),
+    );
     _saveCoins();
   }
 

--- a/gamee/lib/src/view_model/game_state.dart
+++ b/gamee/lib/src/view_model/game_state.dart
@@ -8,7 +8,9 @@ class GameState {
   final double playerX;
   final List<Obstacle> obstacles;
   final List<Bullet> bullets;
-  final int coins;
+  final int coinBalance;
+  final Set<int> purchasedSkinIds;
+  final Set<int> purchasedUpgradeIds;
   final int level;
   final GameMode mode;
 
@@ -18,7 +20,9 @@ class GameState {
     this.playerX = 0.5,
     this.obstacles = const [],
     this.bullets = const [],
-    this.coins = 0,
+    this.coinBalance = 0,
+    this.purchasedSkinIds = const {},
+    this.purchasedUpgradeIds = const {},
     this.level = 1,
     this.mode = GameMode.arcade,
   });
@@ -29,7 +33,9 @@ class GameState {
     double? playerX,
     List<Obstacle>? obstacles,
     List<Bullet>? bullets,
-    int? coins,
+    int? coinBalance,
+    Set<int>? purchasedSkinIds,
+    Set<int>? purchasedUpgradeIds,
     int? level,
     GameMode? mode,
   }) {
@@ -39,7 +45,10 @@ class GameState {
       playerX: playerX ?? this.playerX,
       obstacles: obstacles ?? this.obstacles,
       bullets: bullets ?? this.bullets,
-      coins: coins ?? this.coins,
+      coinBalance: coinBalance ?? this.coinBalance,
+      purchasedSkinIds: purchasedSkinIds ?? this.purchasedSkinIds,
+      purchasedUpgradeIds:
+          purchasedUpgradeIds ?? this.purchasedUpgradeIds,
       level: level ?? this.level,
       mode: mode ?? this.mode,
     );


### PR DESCRIPTION
## Summary
- add models for `SkinItem` and `UpgradeItem`
- extend `GameState` with coin balance and purchased item tracking
- implement purchase helpers in `GameCubit`
- update `GamePage` coin display
- create a functional `StorePage` with tabs for skins and upgrades

## Testing
- `apt-get update` *(passed)*

------
https://chatgpt.com/codex/tasks/task_e_686650218098832aaeab76039c96c07a