### PR TITLE
Add start screen and horizontal controls

### DIFF
--- a/gamee/lib/src/flame/dodgefall_game.dart
+++ b/gamee/lib/src/flame/dodgefall_game.dart
@@ -14,6 +14,7 @@ class DodgefallGame extends FlameGame with HasCollisionDetection, TapDetector {
   final GameCubit cubit;
   late final PlayerComponent player;
   late final _Spawner spawner;
+  bool _started = false;
 
   @override
   Future<void> onLoad() async {
@@ -21,14 +22,24 @@ class DodgefallGame extends FlameGame with HasCollisionDetection, TapDetector {
       'player.png',
       'enemy.png',
     ]);
-    player = PlayerComponent()..position = size / 2;
+    player = PlayerComponent()
+      ..position = Vector2(size.x / 2, size.y - 60);
     add(player);
     spawner = _Spawner(cubit)..position = Vector2.zero();
     add(spawner);
+    pauseEngine();
   }
 
   @override
   void onTapDown(TapDownInfo info) {
+    if (!_started) {
+      _started = true;
+      overlays.remove('start');
+      resumeEngine();
+      super.onTapDown(info);
+      return;
+    }
+
     final bulletPos =
         Vector2(player.x, player.y - player.size.y / 2 - 5);
     add(BulletComponent(bulletPos));
@@ -37,9 +48,9 @@ class DodgefallGame extends FlameGame with HasCollisionDetection, TapDetector {
 
   @override
   void onPanUpdate(DragUpdateInfo info) {
-    final delta = info.delta.global;
-    player.position.add(delta);
-    player.position.clamp(Vector2.zero(), size - player.size);
+    final dx = info.delta.global.x;
+    final newX = (player.x + dx).clamp(player.size.x / 2, size.x - player.size.x / 2);
+    player.position = Vector2(newX, player.y);
   }
 }
 

--- a/gamee/lib/src/view/game_page.dart
+++ b/gamee/lib/src/view/game_page.dart
@@ -22,6 +22,7 @@ class _GamePageState extends State<GamePage> {
   void initState() {
     super.initState();
     _game = DodgefallGame(context.read<GameCubit>());
+    _game.pauseEngine();
   }
 
   @override
@@ -55,8 +56,29 @@ class _GamePageState extends State<GamePage> {
                   ],
                 ),
               ),
+          'start': (_, __) => Stack(
+                children: [
+                  Center(
+                    child: Text(
+                      'нажмите что бы начать',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                  ),
+                  Positioned(
+                    bottom: 32,
+                    left: 0,
+                    right: 0,
+                    child: Center(
+                      child: ElevatedButton(
+                        onPressed: () => Navigator.pushNamed(context, '/store'),
+                        child: const Text('StorePage'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
         },
-        initialActiveOverlays: const ['hud'],
+        initialActiveOverlays: const ['hud', 'start'],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow horizontal-only movement and reposition plane lower in `DodgefallGame`
- pause game initially and start on first tap
- add start overlay with store button in `GamePage`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666d4326bc832a93d32c1844197a00