### PR TITLE
Fix restart and add back button

### DIFF
--- a/gamee/lib/src/flame/dodgefall_game.dart
+++ b/gamee/lib/src/flame/dodgefall_game.dart
@@ -8,13 +8,26 @@ import 'package:flame/input.dart';
 import '../view_model/game_cubit.dart';
 import 'bullet_component.dart';
 
-class DodgefallGame extends FlameGame with HasCollisionDetection, TapDetector {
+class DodgefallGame extends FlameGame
+    with HasCollisionDetection, TapDetector, PanDetector {
   DodgefallGame(this.cubit);
 
   final GameCubit cubit;
   late final PlayerComponent player;
   late final _Spawner spawner;
   bool _started = false;
+
+  void reset() {
+    _started = false;
+    children.whereType<ObstacleComponent>().forEach((e) => e.removeFromParent());
+    children.whereType<BulletComponent>().forEach((b) => b.removeFromParent());
+    player.position = Vector2(size.x / 2, size.y - 60);
+    pauseEngine();
+    overlays
+      ..remove('gameover')
+      ..add('start');
+    cubit.restart();
+  }
 
   @override
   Future<void> onLoad() async {
@@ -32,6 +45,10 @@ class DodgefallGame extends FlameGame with HasCollisionDetection, TapDetector {
 
   @override
   void onTapDown(TapDownInfo info) {
+    if (overlays.isActive('gameover')) {
+      super.onTapDown(info);
+      return;
+    }
     if (!_started) {
       _started = true;
       overlays.remove('start');
@@ -94,6 +111,7 @@ class ObstacleComponent extends SpriteComponent
       removeFromParent();
       gameRef.cubit.addCoins(5);
       gameRef.pauseEngine();
+      gameRef._started = false;
       gameRef.overlays.add('gameover');
     }
     super.onCollisionStart(intersectionPoints, other);

--- a/gamee/lib/src/view/game_page.dart
+++ b/gamee/lib/src/view/game_page.dart
@@ -32,13 +32,27 @@ class _GamePageState extends State<GamePage> {
         game: _game,
         overlayBuilderMap: {
           'hud': (ctx, game) {
-            return BlocBuilder<GameCubit, GameState>(
-              builder: (context, state) {
-                return Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Text('Coins: ${state.coinBalance}'),
-                );
-              },
+            return SafeArea(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    onPressed: () {
+                      _game.reset();
+                      Navigator.pop(context);
+                    },
+                  ),
+                  BlocBuilder<GameCubit, GameState>(
+                    builder: (context, state) {
+                      return Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Text('Coins: ${state.coinBalance}'),
+                      );
+                    },
+                  ),
+                ],
+              ),
             );
           },
           'gameover': (_, __) => Center(
@@ -48,8 +62,7 @@ class _GamePageState extends State<GamePage> {
                     const Text('Game Over'),
                     ElevatedButton(
                       onPressed: () {
-                        _game.overlays.remove('gameover');
-                        _game.resumeEngine();
+                        _game.reset();
                       },
                       child: const Text('Restart'),
                     ),


### PR DESCRIPTION
## Summary
- make `DodgefallGame` react to pan events
- add reset logic to clear enemies and bullets
- block taps when game over screen is visible
- allow restarting via reset and provide back button

## Testing
- `dart --version` *(fails: command not found)*
- `flutter format gamee/lib/src/flame/dodgefall_game.dart gamee/lib/src/view/game_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866736158e4832ab1b0bcb6e097cb65