### PR TITLE
Implement stacking upgrades

### DIFF
--- a/gamee/lib/src/flame/bullet_component.dart
+++ b/gamee/lib/src/flame/bullet_component.dart
@@ -29,7 +29,7 @@ class BulletComponent extends RectangleComponent
   @override
   void onCollisionStart(Set<Vector2> intersectionPoints, PositionComponent other) {
     if (other is ObstacleComponent) {
-      other.health -= 1;
+      other.health -= gameRef.cubit.bulletDamage;
       if (other.health <= 0) {
         other.removeFromParent();
         gameRef.cubit.addCoins(5);

--- a/gamee/lib/src/flame/dodgefall_game.dart
+++ b/gamee/lib/src/flame/dodgefall_game.dart
@@ -18,7 +18,7 @@ class DodgefallGame extends FlameGame
   bool _started = false;
   bool _shooting = false;
   double _shootTimer = 0;
-  final double _shootInterval = 0.2;
+  double get _shootInterval => cubit.shootInterval;
 
   void _shoot() {
     final bulletPos =

--- a/gamee/lib/src/view/store_page.dart
+++ b/gamee/lib/src/view/store_page.dart
@@ -100,21 +100,27 @@ class StorePage extends StatelessWidget {
     return ListView.builder(
       itemCount: _upgrades.length,
       itemBuilder: (context, index) {
+        final cubit = context.read<GameCubit>();
         final up = _upgrades[index];
-        final disabled = state.coinBalance < up.price ||
-            state.purchasedUpgradeIds.contains(up.id);
+        final price = cubit.upgradePrice(up.id);
+        final disabled = state.coinBalance < price;
+        String current;
+        if (up.id == 1) {
+          current = 'Speed: ${(1 / cubit.shootInterval).toStringAsFixed(1)}/s';
+        } else {
+          current = 'Damage: ${cubit.bulletDamage}';
+        }
         return ListTile(
           leading: Icon(up.icon),
           title: Text(up.title),
-          subtitle: Text(up.description),
+          subtitle: Text('${up.description}\n$current'),
           trailing: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text('${up.price}'),
+              Text('$price'),
               const SizedBox(height: 4),
               ElevatedButton(
-                onPressed:
-                    disabled ? null : () => context.read<GameCubit>().purchaseUpgrade(up.id),
+                onPressed: disabled ? null : () => cubit.purchaseUpgrade(up.id),
                 child: const Text('Buy'),
               ),
             ],

--- a/gamee/lib/src/view_model/game_state.dart
+++ b/gamee/lib/src/view_model/game_state.dart
@@ -10,7 +10,8 @@ class GameState {
   final List<Bullet> bullets;
   final int coinBalance;
   final Set<int> purchasedSkinIds;
-  final Set<int> purchasedUpgradeIds;
+  final int attackSpeedLevel;
+  final int damageLevel;
   final int level;
   final GameMode mode;
 
@@ -22,7 +23,8 @@ class GameState {
     this.bullets = const [],
     this.coinBalance = 0,
     this.purchasedSkinIds = const {},
-    this.purchasedUpgradeIds = const {},
+    this.attackSpeedLevel = 0,
+    this.damageLevel = 0,
     this.level = 1,
     this.mode = GameMode.arcade,
   });
@@ -35,7 +37,8 @@ class GameState {
     List<Bullet>? bullets,
     int? coinBalance,
     Set<int>? purchasedSkinIds,
-    Set<int>? purchasedUpgradeIds,
+    int? attackSpeedLevel,
+    int? damageLevel,
     int? level,
     GameMode? mode,
   }) {
@@ -47,8 +50,8 @@ class GameState {
       bullets: bullets ?? this.bullets,
       coinBalance: coinBalance ?? this.coinBalance,
       purchasedSkinIds: purchasedSkinIds ?? this.purchasedSkinIds,
-      purchasedUpgradeIds:
-          purchasedUpgradeIds ?? this.purchasedUpgradeIds,
+      attackSpeedLevel: attackSpeedLevel ?? this.attackSpeedLevel,
+      damageLevel: damageLevel ?? this.damageLevel,
       level: level ?? this.level,
       mode: mode ?? this.mode,
     );


### PR DESCRIPTION
## Summary
- make bullet damage depend on purchased upgrades
- let dodgefall game use cubit's shoot interval
- increase player stats when buying upgrades and allow unlimited purchases
- display current damage and speed in the store

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667d84412c832a80e6f2f55ce45e4d