### PR TITLE
Add game reset option in settings

### DIFF
--- a/gamee/lib/src/view/settings_page.dart
+++ b/gamee/lib/src/view/settings_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../view_model/game_cubit.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
@@ -7,7 +10,47 @@ class SettingsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Настройки')),
-      body: const Center(child: Text('Страница настроек')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Dodgefall — это игра, в которой вы уклоняетесь от препятствий '
+              'и собираете монеты для покупки улучшений и скинов.',
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () async {
+                final confirm = await showDialog<bool>(
+                  context: context,
+                  builder: (context) => AlertDialog(
+                    title: const Text('Очистить данные'),
+                    content: const Text(
+                      'Вы собираетесь удалить всю историю игры. Это действие '
+                      'необратимо.',
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, false),
+                        child: const Text('Отмена'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, true),
+                        child: const Text('Удалить'),
+                      ),
+                    ],
+                  ),
+                );
+                if (confirm == true) {
+                  await context.read<GameCubit>().resetProgress();
+                }
+              },
+              child: const Text('Очистить историю игры'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/gamee/lib/src/view_model/game_cubit.dart
+++ b/gamee/lib/src/view_model/game_cubit.dart
@@ -206,6 +206,12 @@ class GameCubit extends Cubit<GameState> {
     _saveCoins();
   }
 
+  Future<void> resetProgress() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+    emit(const GameState());
+  }
+
   @override
   Future<void> close() {
     _ticker?.cancel();


### PR DESCRIPTION
## Summary
- add full game reset method in `GameCubit`
- update settings page with game description and reset button

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866922bc1ec832aaa8a2d895bcbfaa1