### PR TITLE
Adjust attack speed and store prices

### DIFF
--- a/gamee/lib/src/view/store_page.dart
+++ b/gamee/lib/src/view/store_page.dart
@@ -17,7 +17,7 @@ const List<UpgradeItem> _upgrades = [
     title: 'Attack Speed',
     description: 'Shoot faster',
     icon: Icons.flash_on,
-    price: 150,
+    price: 50,
   ),
   UpgradeItem(
     id: 2,

--- a/gamee/lib/src/view_model/game_cubit.dart
+++ b/gamee/lib/src/view_model/game_cubit.dart
@@ -24,12 +24,12 @@ class GameCubit extends Cubit<GameState> {
   };
 
   static const Map<int, int> _upgradeBasePrices = {
-    1: 150,
+    1: 50,
     2: 200,
   };
 
   int get bulletDamage => 1 + state.damageLevel;
-  double get shootInterval => 0.2 / (1 + state.attackSpeedLevel * 0.1);
+  double get shootInterval => 1.0 / (1 + state.attackSpeedLevel * 0.1);
 
   int upgradePrice(int id) {
     final base = _upgradeBasePrices[id] ?? 0;


### PR DESCRIPTION
## Summary
- slow starting attack speed by default
- lower cost for the first attack speed upgrade and scale further

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68669e1f695c832a9d35568610758a55