### PR TITLE
Add level complete overlay and adjust bounce

### DIFF
--- a/gamee/lib/src/flame/dodgefall_game.dart
+++ b/gamee/lib/src/flame/dodgefall_game.dart
@@ -33,6 +33,7 @@ class DodgefallGame extends FlameGame
   double spawnInterval = 1.0;
   double _levelTimer = 0;
   double _levelDuration = 30;
+  int completedLevel = 0;
   int get obstacleHealth =>
       mode == GameMode.arcade
           ? levelNotifier.value
@@ -72,8 +73,15 @@ class DodgefallGame extends FlameGame
     pauseEngine();
     overlays
       ..remove('gameover')
+      ..remove('levelcomplete')
       ..add('start');
     cubit.restart();
+  }
+
+  void continueAfterLevel() {
+    overlays.remove('levelcomplete');
+    _started = true;
+    resumeEngine();
   }
 
   @override
@@ -157,8 +165,13 @@ class DodgefallGame extends FlameGame
         if (_levelTimer >= _levelDuration) {
           _levelTimer = 0;
           _levelDuration += 5;
+          completedLevel = levelNotifier.value;
           levelNotifier.value += 1;
           spawnInterval = (spawnInterval * 0.9).clamp(0.3, 10.0);
+          _started = false;
+          _stopShooting();
+          pauseEngine();
+          overlays.add('levelcomplete');
         }
       } else {
         // endless mode gradually increases spawn rate
@@ -218,8 +231,8 @@ class ObstacleComponent extends SpriteComponent
       _velocity.y = -_velocity.y * _bounceDamping;
       _velocity.x += (_rand.nextDouble() * 2 - 1) *
           _initialSpeed * _horizontalFactor;
-    } else if (y <= size.y / 2 && _velocity.y < 0) {
-      y = size.y / 2;
+    } else if (y <= gameRef.size.y / 2 && _velocity.y < 0) {
+      y = gameRef.size.y / 2;
       _velocity.y = -_velocity.y * _bounceDamping;
     }
 

--- a/gamee/lib/src/view/game_page.dart
+++ b/gamee/lib/src/view/game_page.dart
@@ -166,6 +166,46 @@ class _GamePageState extends State<GamePage> {
                   ],
                 ),
               ),
+          'levelcomplete': (ctx, game) => Center(
+                child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Поздравляем вы прошли ${game.completedLevel} уровень',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: skyline,
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 32),
+                SizedBox(
+                  width: 280,
+                  height: 60,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: skyline,
+                      elevation: 0,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30),
+                      ),
+                    ),
+                    onPressed: () {
+                      game.continueAfterLevel();
+                    },
+                    child: const Text(
+                      'Дальше',
+                      style: TextStyle(
+                        color: bora,
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            )),
         },
         initialActiveOverlays: const ['hud', 'start'],
       ),


### PR DESCRIPTION
## Summary
- show message overlay when a level is completed in arcade mode
- provide button to continue to the next level
- limit enemy bounces to half of the screen height

## Testing
- `dart format lib/src/flame/dodgefall_game.dart lib/src/view/game_page.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866fc51c624832aa61b147bf4b3be62