### PR TITLE
Add vibration toggle with persistence

### DIFF
--- a/gamee/lib/src/flame/dodgefall_game.dart
+++ b/gamee/lib/src/flame/dodgefall_game.dart
@@ -10,6 +10,7 @@ import '../view_model/game_cubit.dart';
 import '../model/game_mode.dart';
 import 'bullet_component.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 class DodgefallGame extends FlameGame
     with HasCollisionDetection, TapDetector, PanDetector {
@@ -246,6 +247,9 @@ class ObstacleComponent extends SpriteComponent
   ) {
     if (other is PlayerComponent) {
       removeFromParent();
+      if (gameRef.cubit.state.vibrationEnabled) {
+        HapticFeedback.mediumImpact();
+      }
       gameRef.cubit.addCoins(5);
       gameRef.pauseEngine();
       gameRef._started = false;

--- a/gamee/lib/src/view/settings_page.dart
+++ b/gamee/lib/src/view/settings_page.dart
@@ -36,35 +36,83 @@ class SettingsPage extends StatelessWidget {
             ),
             const SizedBox(height: 48),
 
-            for (final label in [
-              'Включить звук',
-              'Включить музыку',
-              'Вибрация',
-            ]) ...[
-              SizedBox(
-                width: 280,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      label,
-                      style: TextStyle(
-                        color: skyline,
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                      ),
+            SizedBox(
+              width: 280,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Включить звук',
+                    style: TextStyle(
+                      color: skyline,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
                     ),
-                    Switch(
-                      value: true,
-                      onChanged: (_) {},
-                      activeColor: Colors.white,
-                      activeTrackColor: skyline,
-                    ),
-                  ],
-                ),
+                  ),
+                  Switch(
+                    value: true,
+                    onChanged: (_) {},
+                    activeColor: Colors.white,
+                    activeTrackColor: skyline,
+                  ),
+                ],
               ),
-              const SizedBox(height: 16),
-            ],
+            ),
+            const SizedBox(height: 16),
+
+            SizedBox(
+              width: 280,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Включить музыку',
+                    style: TextStyle(
+                      color: skyline,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Switch(
+                    value: true,
+                    onChanged: (_) {},
+                    activeColor: Colors.white,
+                    activeTrackColor: skyline,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            BlocBuilder<GameCubit, GameState>(
+              buildWhen: (p, c) => p.vibrationEnabled != c.vibrationEnabled,
+              builder: (context, state) {
+                return SizedBox(
+                  width: 280,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'Вибрация',
+                        style: TextStyle(
+                          color: skyline,
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Switch(
+                        value: state.vibrationEnabled,
+                        onChanged: (v) =>
+                            context.read<GameCubit>().toggleVibration(v),
+                        activeColor: Colors.white,
+                        activeTrackColor: skyline,
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
 
             const SizedBox(height: 48),
             SizedBox(

--- a/gamee/lib/src/view_model/game_cubit.dart
+++ b/gamee/lib/src/view_model/game_cubit.dart
@@ -43,12 +43,14 @@ class GameCubit extends Cubit<GameState> {
     final skins = prefs.getStringList('skins')?.map(int.parse).toSet() ?? {};
     final speed = prefs.getInt('speed') ?? 0;
     final damage = prefs.getInt('damage') ?? 0;
+    final vibration = prefs.getBool('vibration') ?? true;
     emit(
       state.copyWith(
         coinBalance: coins,
         purchasedSkinIds: skins,
         attackSpeedLevel: speed,
         damageLevel: damage,
+        vibrationEnabled: vibration,
       ),
     );
   }
@@ -62,6 +64,7 @@ class GameCubit extends Cubit<GameState> {
     );
     await prefs.setInt('speed', state.attackSpeedLevel);
     await prefs.setInt('damage', state.damageLevel);
+    await prefs.setBool('vibration', state.vibrationEnabled);
   }
 
   void startGame(GameMode mode) {
@@ -184,6 +187,11 @@ class GameCubit extends Cubit<GameState> {
 
   void addCoins(int count) {
     emit(state.copyWith(coinBalance: state.coinBalance + count));
+    _saveState();
+  }
+
+  void toggleVibration(bool enabled) {
+    emit(state.copyWith(vibrationEnabled: enabled));
     _saveState();
   }
 

--- a/gamee/lib/src/view_model/game_state.dart
+++ b/gamee/lib/src/view_model/game_state.dart
@@ -14,6 +14,7 @@ class GameState {
   final int damageLevel;
   final int level;
   final GameMode mode;
+  final bool vibrationEnabled;
 
   const GameState({
     this.isRunning = false,
@@ -27,6 +28,7 @@ class GameState {
     this.damageLevel = 0,
     this.level = 1,
     this.mode = GameMode.arcade,
+    this.vibrationEnabled = true,
   });
 
   GameState copyWith({
@@ -41,6 +43,7 @@ class GameState {
     int? damageLevel,
     int? level,
     GameMode? mode,
+    bool? vibrationEnabled,
   }) {
     return GameState(
       isRunning: isRunning ?? this.isRunning,
@@ -54,6 +57,7 @@ class GameState {
       damageLevel: damageLevel ?? this.damageLevel,
       level: level ?? this.level,
       mode: mode ?? this.mode,
+      vibrationEnabled: vibrationEnabled ?? this.vibrationEnabled,
     );
   }
 }


### PR DESCRIPTION
## Summary
- allow storing vibration preference with `SharedPreferences`
- hook vibration feedback on player death using `HapticFeedback`
- expose vibration switch on Settings page

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867011204ec832aa7eb0fd856e49ac6